### PR TITLE
fix initializing from URL

### DIFF
--- a/app.js
+++ b/app.js
@@ -142,13 +142,13 @@ function setupContrastTool() {
       const bgParam = params.get('bg');
       const thirdParam = params.get('third');
       if (fgParam) {
-        try { const p = parseCssColor(fgParam); fgText.value = fgText.value || p.hex; fgPicker.value = p.hex; } catch {}
+        try { const p = parseCssColor(fgParam); fgText.value = p.hex || fgText.value; fgPicker.value = p.hex; } catch {}
       }
       if (bgParam) {
-        try { const p = parseCssColor(bgParam); bgText.value = bgText.value || p.hex; bgPicker.value = p.hex; } catch {}
+        try { const p = parseCssColor(bgParam); bgText.value = p.hex || bgText.value; bgPicker.value = p.hex; } catch {}
       }
       if (thirdParam) {
-        try { const p = parseCssColor(thirdParam); thirdText.value = thirdText.value || p.hex; thirdPicker.value = p.hex; enableThird.checked = true; thirdContainer.classList.remove('hidden'); } catch {}
+        try { const p = parseCssColor(thirdParam); thirdText.value = p.hex || thirdText.value; thirdPicker.value = p.hex; enableThird.checked = true; thirdContainer.classList.remove('hidden'); } catch {}
       }
     } catch (e) {
       // ignore


### PR DESCRIPTION
When the app is initialized with custom colors, they were overridden by default colors. 
e.g. https://mgifford.github.io/contrast-plus/?fg=%23232323&bg=%23FF415C should be dark text on red background but it's overwritten by the default  green on green colors.